### PR TITLE
商品削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,8 +39,6 @@ class ItemsController < ApplicationController
     redirect_to root_path
   end
 
-
-
   private
 
   def item_params
@@ -53,9 +51,6 @@ class ItemsController < ApplicationController
   end
 
   def redirect
-    unless user_signed_in? && current_user.id == @item.user_id
-      redirect_to root_path
-    end
+    redirect_to root_path unless user_signed_in? && current_user.id == @item.user_id
   end
-  
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :redirect, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :redirect, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order('created_at DESC')
@@ -34,11 +34,10 @@ class ItemsController < ApplicationController
     end
   end
 
-  #def destroy
-  #  @item = Item.find(params[:id])
-  #  @item.destroy
-  #  redirect_to root_path
-  #end
+  def destroy
+    @item.destroy
+    redirect_to root_path
+  end
 
 
 


### PR DESCRIPTION
# What
商品削除機能を実装

# Why
商品投稿者が商品情報を削除できるようにするため

- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/aec29e092630b6d972f2ca71459ea5b0